### PR TITLE
'content' property makes sense only in pseudo elements

### DIFF
--- a/index.md
+++ b/index.md
@@ -814,7 +814,7 @@ One particular feature Sass provides that is being overly misused by many develo
 .foo {
   .bar {
     &:hover {
-      content: baz;
+      color: red;
     }
   }
 }
@@ -825,7 +825,7 @@ One particular feature Sass provides that is being overly misused by many develo
 
 {% highlight css %}
 .foo .bar:hover {
-  content: baz;
+  color: red;
 }
 {% endhighlight %}
 
@@ -834,8 +834,17 @@ Along the same lines, since Sass 3.3 it is possible to use the current selector 
 {% highlight scss %}
 .foo {
   &-bar {
-    content: "Howdy! I am `.foo-bar`.";
+    color: red;
   }
+}
+{% endhighlight %}
+
+... will generate this CSS:
+
+
+{% highlight css %}
+.foo-bar {
+  color: red;
 }
 {% endhighlight %}
 
@@ -853,10 +862,10 @@ To prevent such a situation, we **avoid selector nesting except for pseudo-class
 
 {% highlight scss %}
 .foo {
-  content: "regular";
+  color: red;
 
   &:hover {
-    content: "hovered";
+    color: green;
   }
 
   &::before {


### PR DESCRIPTION
Since property 'content' is made for pseudo-elements, I replaced it with 'color' property in examples.