### PR TITLE
Improve display of quotes for blockquote

### DIFF
--- a/_sass/components/_blockquote.scss
+++ b/_sass/components/_blockquote.scss
@@ -24,7 +24,7 @@ blockquote {
         position: absolute;
         font-size: 20em;
         right: 100%;
-        top: -.32em;
+        top: -.3875em;
         color: rgba(black, .05);
       }
     }


### PR DESCRIPTION
Center the display of the quotes character(s) within `blockquote > :first-child::before` so it is not partially hidden. Normalized for Chrome and Firefox.