### PR TITLE
Fix typo (max-width to min-width)

### DIFF
--- a/index.md
+++ b/index.md
@@ -2641,7 +2641,7 @@ Leading to the following CSS output:
   color: red;
 }
 
-@media (max-width: 800px) {
+@media (min-width: 800px) {
   .foo {
     color: blue;
   }


### PR DESCRIPTION
Small typo fix.

Breakpoints are mobile first (min-width), and example is graceful degradation (max-width).