### PR TITLE
Switching order of colors in tint/shade example functions:

### DIFF
--- a/en/_syntax.md
+++ b/en/_syntax.md
@@ -516,7 +516,7 @@ If you don't want to write the `mix` function every time, you can create two eas
 /// @param {Number} $percentage - percentage of `$color` in returned color
 /// @return {Color}
 @function tint($color, $percentage) {
-  @return mix($color, white, $percentage);
+  @return mix(white, $color, $percentage);
 }
 
 /// Slightly darken a color
@@ -525,7 +525,7 @@ If you don't want to write the `mix` function every time, you can create two eas
 /// @param {Number} $percentage - percentage of `$color` in returned color
 /// @return {Color}
 @function shade($color, $percentage) {
-  @return mix($color, black, $percentage);
+  @return mix(black, $color, $percentage);
 }
 {% endhighlight %}
   </div>

--- a/es/_syntax.md
+++ b/es/_syntax.md
@@ -514,7 +514,7 @@ Si no quieres escribir la función `mix` cada vez que quieras usarla, puedes cre
 /// @param {Number} $percentage - porcentaje del `$color` que debe ser devuelto
 /// @return {Color}
 @function tint($color, $percentage) {
-  @return mix($color, white, $percentage);
+  @return mix(white, $color, $percentage);
 }
 
 /// Oscurecer ligeramente un color
@@ -523,7 +523,7 @@ Si no quieres escribir la función `mix` cada vez que quieras usarla, puedes cre
 /// @param {Number} $percentage - porcentaje de `$color` que debe ser devuelto
 /// @return {Color}
 @function shade($color, $percentage) {
-  @return mix($color, black, $percentage);
+  @return mix(black, $color, $percentage);
 }
 {% endhighlight %}
   </div>

--- a/fr/_syntax.md
+++ b/fr/_syntax.md
@@ -520,7 +520,7 @@ Si vous ne voulez pas écrire la fonction `mix` à chaque fois, vous pouvez cré
 /// @param {Number} $percentage - % de`$color` dans la couleur retournée
 /// @return {Color}
 @function tint($color, $percentage) {
-  @return mix($color, white, $percentage);
+  @return mix(white, $color, $percentage);
 }
 
 /// Obscurcir légèrement une couleur
@@ -529,7 +529,7 @@ Si vous ne voulez pas écrire la fonction `mix` à chaque fois, vous pouvez cré
 /// @param {Number} $percentage - % de`$color` dans la couleur retournée
 /// @return {Color}
 @function shade($color, $percentage) {
-  @return mix($color, black, $percentage);
+  @return mix(black, $color, $percentage);
 }
 {% endhighlight %}
   </div>

--- a/ko/_syntax.md
+++ b/ko/_syntax.md
@@ -511,7 +511,7 @@ $main-theme-color: $sass-pink
 /// @param {Number} $percentage - percentage of `$color` in returned color
 /// @return {Color}
 @function tint($color, $percentage) {
-  @return mix($color, white, $percentage);
+  @return mix(white, $color, $percentage);
 }
 
 /// Slightly darken a color
@@ -520,7 +520,7 @@ $main-theme-color: $sass-pink
 /// @param {Number} $percentage - percentage of `$color` in returned color
 /// @return {Color}
 @function shade($color, $percentage) {
-  @return mix($color, black, $percentage);
+  @return mix(black, $color, $percentage);
 }
 {% endhighlight %}
   </div>

--- a/pl/_syntax.md
+++ b/pl/_syntax.md
@@ -524,7 +524,7 @@ Jeśli nie chcesz używać pełnej funkcji `mix` za każdym razem, możesz stwor
 /// @param {Number} $percentage - procent pierwotnego `$color` w zwróconej wartości
 /// @return {Color}
 @function tint($color, $percentage) {
-  @return mix($color, white, $percentage);
+  @return mix(white, $color, $percentage);
 }
 
 /// Stopniowo przyciemniaj kolor
@@ -533,7 +533,7 @@ Jeśli nie chcesz używać pełnej funkcji `mix` za każdym razem, możesz stwor
 /// @param {Number} $percentage - procent pierwotnego `$color` w zwróconej wartości
 /// @return {Color}
 @function shade($color, $percentage) {
-  @return mix($color, black, $percentage);
+  @return mix(black, $color, $percentage);
 }
 {% endhighlight %}
   </div>

--- a/ru/_syntax.md
+++ b/ru/_syntax.md
@@ -516,7 +516,7 @@ $main-theme-color: $sass-pink
 /// @param {Number} $percentage - процент от `$color` в возвращаемом цвете
 /// @return {Color}
 @function tint($color, $percentage) {
-  @return mix($color, white, $percentage);
+  @return mix(white, $color, $percentage);
 }
 
 /// Немного затемнить цвет
@@ -525,7 +525,7 @@ $main-theme-color: $sass-pink
 /// @param {Number} $percentage - процент от `$color` в возвращаемом цвете
 /// @return {Color}
 @function shade($color, $percentage) {
-  @return mix($color, black, $percentage);
+  @return mix(black, $color, $percentage);
 }
 {% endhighlight %}
   </div>

--- a/zh/_syntax.md
+++ b/zh/_syntax.md
@@ -515,7 +515,7 @@ $main-theme-color: $sass-pink
 /// @param {Number} $percentage - percentage of `$color` in returned color
 /// @return {Color}
 @function tint($color, $percentage) {
-  @return mix($color, white, $percentage);
+  @return mix(white, $color, $percentage);
 }
 
 /// Slightly darken a color
@@ -524,7 +524,7 @@ $main-theme-color: $sass-pink
 /// @param {Number} $percentage - percentage of `$color` in returned color
 /// @return {Color}
 @function shade($color, $percentage) {
-  @return mix($color, black, $percentage);
+  @return mix(black, $color, $percentage);
 }
 {% endhighlight %}
   </div>


### PR DESCRIPTION
It seems `tint` and `shade` examples don't work as intented.

Let's say I want to darken by 10%, I have to write `shade($color, 90%)` if using the given example.
Changing order of passed colors to `mix` fixes it and let me write `shade($color, 10%);`

Thanks for the guidelines :)