### PR TITLE
ui: remove underline on section's anchor links

### DIFF
--- a/_sass/components/_heading-anchors.scss
+++ b/_sass/components/_heading-anchors.scss
@@ -7,4 +7,5 @@
   font-size: .8em;
   top: .2em;
   color:  $light-grey;
+  text-decoration: none;
 }


### PR DESCRIPTION

![screen shot 2015-05-22 at 2 37 04 pm](https://cloud.githubusercontent.com/assets/1754041/7777392/908eef10-0090-11e5-91c2-5e8e3bede66a.png)
 
to ![screen shot 2015-05-22 at 2 37 27 pm](https://cloud.githubusercontent.com/assets/1754041/7777399/985b12c8-0090-11e5-8383-242de88e9a57.png)

images were taken on `:hover` to show more contrast

thoughts?