### PR TITLE
promote buttons to their own layer

### DIFF
--- a/assets/sass/components/_button.scss
+++ b/assets/sass/components/_button.scss
@@ -86,6 +86,7 @@
   left: auto;
   position: fixed;
   right: 0;
+  will-change: transform;
 }
 
 .button-ui--back {


### PR DESCRIPTION
Promoting elements with `position: fixed` to their own layer will reduce the overall repaint of the site.

See https://aerotwist.com/blog/bye-bye-layer-hacks/ for more information