### PR TITLE
Fix typo on code block (fr-FR)

### DIFF
--- a/_includes/snippets/architecture/06/fr.html
+++ b/_includes/snippets/architecture/06/fr.html
@@ -1,4 +1,4 @@
-g<div class="code-block">
+<div class="code-block">
   <div class="code-block__wrapper" data-syntax="scss">
 {% highlight scss %}
 // Variables spécifiques aux boutons


### PR DESCRIPTION
Remove the `g` who break the div.