### PR TITLE
added "Rewrote the section about PostCSS" into the 1.3 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Improved wording here and there ([ddb46ab](https://github.com/HugoGiraudel/sass-guidelines/commit/ddb46ab))
 * Updated wording that could be considered insensitive ([67e7395](https://github.com/HugoGiraudel/sass-guidelines/commit/67e7395))
 * Updated author’s age ([c021429](https://github.com/HugoGiraudel/sass-guidelines/commit/c021429))
+* Rewrote the section about PostCSS ([7df1809](https://github.com/HugoGiraudel/sass-guidelines/commit/7df1809c7a771e82202d7b910c542b3fd687d3f3))
 
 ### Deletions
 


### PR DESCRIPTION
"[Rewrote the section about PostCSS](https://github.com/HugoGiraudel/sass-guidelines/pull/292/commits/7df1809c7a771e82202d7b910c542b3fd687d3f3)" seems to be merged into gh-pages (based on the 1.3 PR) but isn't not mentioned in the Changelog.