### PR TITLE
Added missing fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,9 @@
 {
+  "name": "sass-guidelines",
+  "version": "1.3.0",
+  "description": "An opinionated styleguide for writing sane, maintainable and scalable Sass.",
+  "repository": "hugogiraudel/sass-guidelines",
+  "license": "MIT",
   "scripts": {
     "postinstall": "npm run js:vendors",
     "build": "npm run icons && npm run js:build",


### PR DESCRIPTION
:wave:

This adds some missing fields to the `package.json` which resulted in `npm WARN` messages during installation. While I was on it, I also added some more basic information including the version number which will be relevant for an upcoming ServiceWorker update.