### PR TITLE
Adding offline support

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,7 +30,7 @@ exclude: [
   "assets/images/icons",
   "package.json", "Gemfile", "Gemfile.lock",
   "README.md", "pages/**/README.md", "LICENSE", "CNAME",
-  "node_modules", "vendor", "_bin"
+  "node_modules", "vendor", "_bin",
   "sw-precache-config.js"
 ]
 

--- a/_config.yml
+++ b/_config.yml
@@ -31,6 +31,7 @@ exclude: [
   "package.json", "Gemfile", "Gemfile.lock",
   "README.md", "pages/**/README.md", "LICENSE", "CNAME",
   "node_modules", "vendor", "_bin"
+  "sw-precache-config.js"
 ]
 
 markdown: kramdown

--- a/_plugins/generate-sw.rb
+++ b/_plugins/generate-sw.rb
@@ -1,6 +1,4 @@
 Jekyll::Hooks.register :site, :post_write do |site|
-  Dir.chdir('_site') {
-    result = `sw-precache`
-    Jekyll.logger.info 'Generated ServiceWorker'
-  }
+  result = `sw-precache --config=sw-precache-config.js --root=_site`
+  Jekyll.logger.info 'Generated ServiceWorker'
 end

--- a/_plugins/generate-sw.rb
+++ b/_plugins/generate-sw.rb
@@ -1,4 +1,4 @@
 Jekyll::Hooks.register :site, :post_write do |site|
-  result = `sw-precache --config=sw-precache-config.js --root=_site`
+  result = `./node_modules/.bin/sw-precache --config=sw-precache-config.js --root=_site`
   Jekyll.logger.info 'Generated ServiceWorker'
 end

--- a/_plugins/generate-sw.rb
+++ b/_plugins/generate-sw.rb
@@ -1,0 +1,6 @@
+Jekyll::Hooks.register :site, :post_write do |site|
+  Dir.chdir('_site') {
+    result = `sw-precache`
+    Jekyll.logger.info 'Generated ServiceWorker'
+  }
+end

--- a/assets/js/src/app.js
+++ b/assets/js/src/app.js
@@ -164,4 +164,22 @@
     initialiseOptionsPanel()
     initialiseChapters()
   })
+
+  // Install service worker
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker
+      .register('/service-worker.js', { scope: '/' })
+      .then(function (registration) {
+        console.log(
+          '%cserviceworker:registration', 'color:green',
+          `successful with scope: ${registration.scope}`
+        )
+      })
+      .catch(function (error) {
+        console.error(
+          '%cserviceworker:registration', 'color:red',
+          'failed: ', error
+        )
+      })
+  }
 }())

--- a/package.json
+++ b/package.json
@@ -9,11 +9,12 @@
     "start": "nps"
   },
   "dependencies": {
+    "OptimizedWebfontLoading": "gist:2a65d6a37675412a2463",
     "a11y-dialog": "^3.0.0",
     "blingdotjs": "gist:7d867cda127e64d38f28",
     "fg-loadcss": "^1.2.0",
-    "OptimizedWebfontLoading": "gist:2a65d6a37675412a2463",
     "picturefill": "^3.0.2",
+    "sw-precache": "^4.3.0",
     "woff2-feature-test": "^1.0.2"
   },
   "devDependencies": {

--- a/sw-precache-config.js
+++ b/sw-precache-config.js
@@ -1,8 +1,8 @@
 module.exports = {
   runtimeCaching: [
     {
-      urlPattern: /^https?:\/\/(.*?).cloudfront.net\/bundles\/(.*?).js$/,
-      handler: 'networkFirst'
+      urlPattern: /^https?:\/\/\w+.cloudfront.net\/bundles\/\w+.js$/,
+      handler: 'cacheFirst'
     }
   ]
 }

--- a/sw-precache-config.js
+++ b/sw-precache-config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  runtimeCaching: [
+    {
+      urlPattern: /^https?:\/\/(.*?).cloudfront.net\/bundles\/(.*?).js$/,
+      handler: 'networkFirst'
+    }
+  ]
+}


### PR DESCRIPTION
This is a pull request for #297.

As discussed in the issue, the ServiceWorker is automatically generated via [sw-precache](https://github.com/GoogleChrome/sw-precache) after Jekyll has build the website. I've added a tiny [Jekyll plugin](https://github.com/HugoGiraudel/sass-guidelines/compare/feature/offline-support?expand=1#diff-c6c90a93e3fe20144d1b83537e1b6e60) which runs the `sw-precache` command. The benefit with this approach is, we don't have to manually define the to-be-cached files but let `sw-precache` take care of it automatically. 

Because the production website works with a bundled & minified (hashed) JS file, I've added an [option](https://github.com/HugoGiraudel/sass-guidelines/compare/feature/offline-support?expand=1#diff-fbd4ae209586a299bf5d3e910f1eab22R4) to add the file dynamically on runtime to the cache.

:v:

**edit:** Travis seems to fail because it doesn't install Node.js dependencies?