### PR TITLE
@charset should use double quotes

### DIFF
--- a/_includes/snippets/syntax/02/index.html
+++ b/_includes/snippets/syntax/02/index.html
@@ -2,12 +2,12 @@
 <div class="code-block">
   <div class="code-block__wrapper" data-syntax="scss">
 {% highlight scss %}
-@charset 'utf-8';
+@charset "utf-8";
 {% endhighlight %}
   </div>
   <div class="code-block__wrapper" data-syntax="sass">
 {% highlight sass %}
-@charset 'utf-8'
+@charset "utf-8"
 {% endhighlight %}
   </div>
 </div>


### PR DESCRIPTION
According to MDN (https://developer.mozilla.org/en-US/docs/Web/CSS/@charset#Syntax), the `@charset` at-rule should use double quotes.

Kind regards,
Johan